### PR TITLE
Fix bad serial data causing exceptions

### DIFF
--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -82,7 +82,8 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
       try {
         term.io.writeUTF8(str.buffer);
       } catch (error) { 
-        log.print(e); 
+        log.println("str was ", str)
+        log.println(e); 
       }
     });
     term.installKeyboard();

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -80,7 +80,9 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     usbBack.readloop(str => {
       try {
         term.io.print(str);
-      } catch (err) { 
+      } catch (err) {
+        // Catch the exception for now and log it. Sometimes bad data gets through
+        // and I don't know how to convert junk into question marks for the string.
         console.error("str was ", str)
         console.error(err); 
       }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -79,7 +79,11 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
 
     term.decorate(this._terminal);
     usbBack.readloop(str => {
-      term.io.writeUTF8(str.buffer);
+      try {
+        term.io.writeUTF8(str.buffer);
+      } catch (error) { 
+        log.print(e); 
+      }
     });
     term.installKeyboard();
   }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -78,7 +78,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
 
     term.decorate(this._terminal);
     usbBack.readloop(str => {
-      term.io.writeUTF8(str.buffer);
+      term.io.writeUTF8(new Uint8Array(str.buffer));
     });
     term.installKeyboard();
   }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -78,7 +78,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
 
     term.decorate(this._terminal);
     usbBack.readloop(str => {
-      term.io.writeUTF8(str);
+      term.io.writeUTF8(str.buffer);
     });
     term.installKeyboard();
   }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -78,7 +78,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
 
     term.decorate(this._terminal);
     usbBack.readloop(str => {
-      term.io.print(str);
+      term.io.writeUTF8(str);
     });
     term.installKeyboard();
   }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -59,6 +59,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     // implementations then this will scope all preferences read/writes to this
     // name.
     const term = (this._term = new hterm.Terminal('default'));
+    term.getPrefs().set('receive-encoding', 'raw');
     term.onTerminalReady = function () {
       // Create a new terminal IO object and give it the foreground.
       // (The default IO object just prints warning messages about unhandled
@@ -78,7 +79,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
 
     term.decorate(this._terminal);
     usbBack.readloop(str => {
-      term.io.writeUTF8(new Uint8Array(str.buffer));
+      term.io.writeUTF8(str.buffer);
     });
     term.installKeyboard();
   }

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -79,7 +79,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     term.decorate(this._terminal);
     usbBack.readloop(str => {
       try {
-        term.io.writeUTF8(str);
+        term.io.print(str);
       } catch (err) { 
         console.error("str was ", str)
         console.error(err); 

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -82,8 +82,8 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
       try {
         term.io.writeUTF8(str.buffer);
       } catch (error) { 
-        log.println("str was ", str)
-        log.println(e); 
+        console.error("str was ", str)
+        console.error(e); 
       }
     });
     term.installKeyboard();

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -59,7 +59,6 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     // implementations then this will scope all preferences read/writes to this
     // name.
     const term = (this._term = new hterm.Terminal('default'));
-    term.getPrefs().set('receive-encoding', 'raw');
     term.onTerminalReady = function () {
       // Create a new terminal IO object and give it the foreground.
       // (The default IO object just prints warning messages about unhandled
@@ -80,7 +79,7 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     term.decorate(this._terminal);
     usbBack.readloop(str => {
       try {
-        term.io.writeUTF8(str.buffer);
+        term.io.writeUTF8(str);
       } catch (err) { 
         console.error("str was ", str)
         console.error(err); 

--- a/components/hdctools_console_view/hdctools-console-view.js
+++ b/components/hdctools_console_view/hdctools-console-view.js
@@ -81,9 +81,9 @@ class HdctoolsConsoleView extends connect(store)(PageViewElement) {
     usbBack.readloop(str => {
       try {
         term.io.writeUTF8(str.buffer);
-      } catch (error) { 
+      } catch (err) { 
         console.error("str was ", str)
-        console.error(e); 
+        console.error(err); 
       }
     });
     term.installKeyboard();

--- a/src/device/lib.js
+++ b/src/device/lib.js
@@ -31,7 +31,7 @@ export class UsbConsole {
         ep.packetSize
       );
 
-      if (data) {
+      if (status == 'ok' && data) {
         onRx(data);
       }
 

--- a/src/device/lib.js
+++ b/src/device/lib.js
@@ -16,6 +16,7 @@ export class UsbConsole {
   }
 
   async readloop(onRx) {
+    const decoder = new TextDecoder();
     const device = this._device;
     /* Seems that sometimes the Promise hasn't completed yet */
     if (this._intf.alternate === null) {
@@ -32,7 +33,7 @@ export class UsbConsole {
       );
 
       if (status == 'ok' && data) {
-        onRx(data);
+        onRx(decoder.decode(data, {stream: true}));
       }
 
       if (status == 'stall') break;

--- a/src/device/lib.js
+++ b/src/device/lib.js
@@ -16,7 +16,6 @@ export class UsbConsole {
   }
 
   async readloop(onRx) {
-    const decoder = new TextDecoder();
     const device = this._device;
     /* Seems that sometimes the Promise hasn't completed yet */
     if (this._intf.alternate === null) {
@@ -33,7 +32,7 @@ export class UsbConsole {
       );
 
       if (data) {
-        onRx(decoder.decode(data));
+        onRx(data);
       }
 
       if (status == 'stall') break;


### PR DESCRIPTION
It seems that sometimes a single byte comes over the wire and we hit an exception

Uncaught (in promise) TypeError: r.next is not a function
    at Function.lo.TextAttributes.splitWidecharString (app.js:12)
    at lo.Terminal.print (app.js:12)
    at r (app.js:12)
    at lo.VT.parseUnknown_ (app.js:12)
    at lo.VT.interpret (app.js:12)
    at lo.Terminal.interpret (app.js:12)
    at lo.Terminal.IO.print.lo.Terminal.IO.writeUTF16 (app.js:12)
    at hdctools-console-view.js:80
    at N.readloop (lib.js:32)

It looks like we're trying to parse the data coming over the wire and we think
 it's a UTF16 codepoint but it's probably just junk/noise. This usually happens
when we reboot the board. Switch to using writeUTF8() so that we don't try
to write strings that need to be parsed, but just raw bytes.

Signed-off-by: Stephen Boyd <swboyd@chromium.org>